### PR TITLE
Closes #6. Add missing `rebind` for `AlignmentAllocator<T2, 1>`.

### DIFF
--- a/levenshtein-sse.hpp
+++ b/levenshtein-sse.hpp
@@ -143,6 +143,11 @@ template <typename T>
 class AlignmentAllocator<T, 1> : public std::allocator<T> {
 public:
   static constexpr bool usesMMAlloc = false;
+
+  template <typename T2>
+  struct rebind {
+    typedef AlignmentAllocator<T2, 1> other;
+  };
 };
 
 #ifdef __SSSE3__


### PR DESCRIPTION
Add missing `rebind` implementation for the instantiation of `AlignmentAllocator<T,N>` with `N=1`.
This was causing a compiler error in gcc 13.2.

Closes #6.